### PR TITLE
Add support for occasions when max count is unknown

### DIFF
--- a/examples/stdinorfile.pl
+++ b/examples/stdinorfile.pl
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Term::ProgressBar 2.00;
+
+my $input_file = shift;
+my $output_file = shift;
+my $in_fh = \*STDIN;
+my $out_fh = \*STDOUT;
+my $message_fh = \*STDERR;
+my $num_lines = -1;
+
+if(defined($input_file) and $input_file ne '-') {
+	open($in_fh, $input_file) or die "Couldn't open file, '$input_file', for reading: $!";
+	my $wc_output = `wc -l $input_file`;
+	chomp($wc_output);
+	$wc_output =~ /^\s*(\d+)(\D.*)?/ or die "Couldn't parse wc output: $wc_output";
+	$num_lines = $1;
+}
+
+if(defined($output_file)) {
+	!-f $output_file or die "Specified output file, '$output_file', already exists";
+	open($out_fh, '>', $output_file) or die "Couldn't open output file, '$output_file', for writing: $!";
+}
+
+my $progress = Term::ProgressBar->new({
+	name	=> 'file processor',
+	count	=> $num_lines,
+	remove	=> 1,
+	fh		=> $message_fh,
+});
+
+while(my $line = <$in_fh>) {
+	chomp($line);
+	print $out_fh "I found a line: $line\n";
+	$progress->message("Found 10000!") if($line =~ /10000/);
+	$progress->update();
+}
+
+$progress->update($num_lines);
+
+print $message_fh "Finished\n";

--- a/lib/Term/ProgressBar.pm
+++ b/lib/Term/ProgressBar.pm
@@ -143,6 +143,67 @@ progress bar from the terminal when done.
 The complete text of this example is in F<examples/powers3> in the
 distribution set (it is not installed as part of the module.
 
+=head2 When the maximum number of items is sometimes unknown
+
+Sometimes you may wish to use the progress bar when the number of items may or
+may not be known. One common example is when you write a script that can take
+input piped from the output of another command, and then pipe the output to yet
+another command. eg:
+
+  some_command --arg value | my_script.pl | some_other_command
+
+Or ...
+
+  my_script.pl input_file output_file
+
+This example shows how you can iterate over a file specified on the command line
+with the progress bar. Since the input file may be read from STDIN, the number
+of lines may not be known. Term::ProgressBar handles this by just taking '-1' as
+the count value and with no further changes to the code. By calling update
+with the same count value, you ensure the progress bar is removed afterwards.
+
+  my $input_file = shift;
+  my $output_file = shift;
+  my $in_fh = \*STDIN;
+  my $out_fh = \*STDOUT;
+  my $message_fh = \*STDERR;
+  my $num_lines = -1;
+
+  if(defined($input_file) and $input_file ne '-') {
+    open($in_fh, $input_file) or die "Couldn't open file, '$input_file': $!";
+    my $wc_output = `wc -l $input_file`;
+    chomp($wc_output);
+    $wc_output =~ /^\s*(\d+)(\D.*)?/ or die "Couldn't parse wc output: $wc_output";
+    $num_lines = $1;
+  }
+
+  if(defined($output_file)) {
+    !-f $output_file or die "Specified output file, '$output_file', already exists";
+    open($out_fh, '>', $output_file) or die "Couldn't open output file, '$output_file': $!";
+  }
+
+  my $progress = Term::ProgressBar->new({
+    name  => 'file processor',
+    count  => $num_lines,
+    remove  => 1,
+    fh    => $message_fh,
+  });
+
+  while(my $line = <$in_fh>) {
+    chomp($line);
+    print $out_fh "I found a line: $line\n";
+    $progress->message("Found 10000!") if($line =~ /10000/);
+    $progress->update();
+  }
+
+  $progress->update($num_lines);
+
+  print $message_fh "Finished\n";
+
+When the file is defined explicitly, the progress bar displays the linewise
+progress through the file. Since the progress bar by default prints output to
+stderr, your scripts output to STDOUT will not be affected.
+
 =head2 Using Completion Time Estimation
 
   my $progress = Term::ProgressBar->new({name  => 'Powers',
@@ -349,6 +410,12 @@ a number, being equivalent to the C<count> key.
 
 The item count.  The progress is marked at 100% when update I<count> is
 invoked, and proportionally until then.
+
+If you specify a count less than zero, just the name (if specified) will be 
+displayed and (if the remove flag is set) removed when the progress bar is 
+updated with a number lower than zero. This allows you to use the progress bar
+when the count is sometimes known and sometimes not without making multiple
+changes throughout your code.
 
 =item name
 
@@ -785,13 +852,28 @@ sub update {
   my $name = $self->name;
   my $fh = $self->fh;
 
-  if ( $target < 1 ) {
+  
+  if ( $target < 0 ) {
     if($input_so_far <= 0 or $input_so_far == $self->last_update) {
       print $fh "\r", ' ' x $self->term_width, "\r";
-      printf $fh "$name..."
-        if defined $name and $input_so_far >= 0;
+      
+      if(defined $name) {
+        if(!$self->remove or $input_so_far >= 0) {
+          print $fh "$name...";
+        }
+		if(!$self->remove and $input_so_far < 0) {
+		  print $fh "\n";
+        }
+      }
     }
+    $self->last_update($input_so_far);
     return 2**32-1;
+  } elsif ( $target == 0 ) {
+    print $fh "\r";
+    printf $fh "$name: "
+      if defined $name;
+    print $fh "(nothing to do)\n";
+	return 2**32-1;
   }
 
   my $biggies     = $self->major_units * $so_far;

--- a/lib/Term/ProgressBar.pm
+++ b/lib/Term/ProgressBar.pm
@@ -786,10 +786,11 @@ sub update {
   my $fh = $self->fh;
 
   if ( $target < 1 ) {
-    print $fh "\r";
-    printf $fh "$name: "
-      if defined $name;
-    print $fh "(nothing to do)\n";
+    if($input_so_far <= 0 or $input_so_far == $self->last_update) {
+      print $fh "\r", ' ' x $self->term_width, "\r";
+      printf $fh "$name..."
+        if defined $name and $input_so_far >= 0;
+    }
     return 2**32-1;
   }
 

--- a/t/lessthanzero.t
+++ b/t/lessthanzero.t
@@ -1,0 +1,102 @@
+# (X)Emacs mode: -*- cperl -*-
+
+use strict;
+use warnings;
+
+=head1 Unit Test Package for Term::ProgressBar
+
+This package tests the zero-progress handling of progress bar.
+
+=cut
+
+use Test::More tests => 10;
+use Test::Exception;
+
+use Capture::Tiny qw(capture_stderr);
+
+use_ok 'Term::ProgressBar';
+
+Term::ProgressBar->__force_term (50);
+
+# -------------------------------------
+
+=head2 Tests 2--4: V1 mode
+
+Create a progress bar with fewer than -1 things.
+Update it it from 1 to 10.
+
+(1) Check no exception thrown on creation
+(2) Check no exception thrown on update
+(3) Check bar displays name
+
+=cut
+
+{
+  my $p;
+  my $name = 'doing nothing';
+  my $err  = capture_stderr {
+    lives_ok { $p = Term::ProgressBar->new($name, -1); } 'V1 mode ( 1)';
+    lives_ok { $p->update($_) for 1..10 } 'V1 mode ( 2)';
+  };
+
+  my @lines = grep { $_ ne ''} split /\r/, $err;
+  diag explain @lines
+    if $ENV{TEST_DEBUG};
+  like $lines[-1], qr/^$name...$/,                                  'V1 mode ( 3)';
+}
+
+# -------------------------------------
+
+=head2 Tests 5--7: V2 mode
+
+Create a progress bar with -1 things.
+Update it it from 1 to 10.
+
+(1) Check no exception thrown on creation
+(2) Check no exception thrown on update
+(3) Check bar displays name
+
+=cut
+
+{
+  my $p;
+  my $name = 'doing nothing';
+  my $err = capture_stderr {
+    lives_ok { $p = Term::ProgressBar->new({ count => -1, name => $name }); } 'V2 mode ( 1)';
+    lives_ok { $p->update($_) for 1..10 } 'V2 mode ( 2)';
+  };
+
+  my @lines = grep {$_ ne ''} split /\r/, $err;
+  diag explain @lines
+    if $ENV{TEST_DEBUG};
+  like $lines[-1], qr/^$name...$/,             'V2 mode ( 3)';
+}
+
+# -------------------------------------
+
+=head2 Tests 8--10: V2 mode
+
+Create a progress bar with -1 things and remove = 1.
+Update it with -1
+
+(1) Check no exception thrown on creation
+(2) Check no exception thrown on update
+(3) Check bar is removed
+
+=cut
+
+{
+  my $p;
+  my $name = 'doing nothing';
+  my $err = capture_stderr {
+    lives_ok { $p = Term::ProgressBar->new({ count => -1, name => $name, remove => 1 }); } 'V2 mode ( 1)';
+    lives_ok { $p->update(-1) } 'V2 mode ( 2)';
+  };
+
+  my @lines = grep {$_ ne ''} split /\r/, $err;
+  diag explain @lines
+    if $ENV{TEST_DEBUG};
+  like $lines[-1], qr/^\s*$/,             'V2 mode ( 3)';
+}
+
+# ----------------------------------------------------------------------------


### PR DESCRIPTION
I have scripts that sometimes know the maximum count (eg when taken from a file) but sometimes don't (eg taken from STDIN). Rather than add extra code that allows me to either use the progress bar, or not, and either use progress->message() or not, this little change allows you to set the count = -1 and keep using the other progress bar code.

This code means that on the first call to update() from init(), or following a call to message() it simply prints the name of the progress bar. If it is called with a value < 0, (such as updating to the 'count' when 'count' < 0, it will blank and reset the line.

For example:

	defined($num_items) or $num_items = -1;
	
	my $progress = Term::ProgressBar->new ({
		count	=> $num_items,
		remove	=> 1,
		ETA		=> 'linear',
		name	=> 'Retrieving item details',
		silent	=> $parameters->{silent},
	});
	
	my $counter = 0;
	
	while(1) {
		my $next_item = get_next_item() or last;
		$progress->update($counter++);
		$progress->message("I can still use this functionality whether I know the max number or not");
	}
	
	$progress->update($num_items);
	# The line is blank.
	